### PR TITLE
Exported mac_address_for function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,3 +119,4 @@ exports.get_active_interface = function(cb) {
 };
 
 exports.get_interfaces_list = os_functions.get_network_interfaces_list;
+exports.mac_address_for = os_functions.mac_address_for;


### PR DESCRIPTION
This would be handy and save me (and I'm sure many others) from importing another module just for getting the mac address.