### PR TITLE
Linux MAC address correction

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -30,7 +30,7 @@ exports.interface_type_for = function(nic_name, cb) {
 };
 
 exports.mac_address_for = function(nic_name, cb) {
-  var cmd = "ifconfig | grep " + nic_name + " | grep 'HWaddr' | awk '{print $5}'";
+  var cmd = "ifconfig " + nic_name + " | grep 'HWaddr' | awk '{print $5}'";
   exec(cmd, cb);
 };
 


### PR DESCRIPTION
I encountered an issue regarding the MAC address report.
In case a Linux interface is configured for several addresses (for example: eth0 and eth0:1) the MAC address were reported twice (i.e. MAC\nMAC) because 'grep' catches all 'eth0'-prefixed interface names.
Passing ifconfig the interface as argument fixes this problem as only one interface is reported.

PS: thanks for this lib, this is the only one functional among the numerous existing for local networking configuration reporting.