### PR TITLE
Allow the user to override what URLs to use for IP lookup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,13 @@
 //////////////////////////////////////////
 
 var needle       = require('needle'),
-    os_functions = require('./' + process.platform);
+    os_functions = require('./' + process.platform),
+    urls         = [
+      'checkip.dyndns.org',
+      'http://wtfismyip.com/text',
+      'http://ipecho.net/plain',
+      'http://ifconfig.me/ip'
+    ];
 
 // var ip_regex = /((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})/;
 var ip_regex = /(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)/;
@@ -31,13 +37,6 @@ var nic_by_name = function(name, cb) {
 };
 
 exports.get_public_ip  = function(cb) {
-
-  var urls  = [
-    'checkip.dyndns.org',
-    'http://wtfismyip.com/text',
-    'http://ipecho.net/plain',
-    'http://ifconfig.me/ip'
-  ];
 
   var get = function(i) {
     var url = urls[i];
@@ -117,5 +116,10 @@ exports.get_active_interface = function(cb) {
   });
 
 };
+
+exports.set_lookup_urls = function(new_urls){
+
+  urls = new_urls;
+}
 
 exports.get_interfaces_list = os_functions.get_network_interfaces_list;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,13 +5,7 @@
 //////////////////////////////////////////
 
 var needle       = require('needle'),
-    os_functions = require('./' + process.platform),
-    urls         = [
-      'checkip.dyndns.org',
-      'http://wtfismyip.com/text',
-      'http://ipecho.net/plain',
-      'http://ifconfig.me/ip'
-    ];
+    os_functions = require('./' + process.platform);
 
 // var ip_regex = /((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})/;
 var ip_regex = /(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)/;
@@ -36,7 +30,14 @@ var nic_by_name = function(name, cb) {
 
 };
 
-exports.get_public_ip  = function(cb) {
+exports.get_public_ip  = function(lookup_urls, cb) {
+
+  var urls  = [
+    'checkip.dyndns.org',
+    'http://wtfismyip.com/text',
+    'http://ipecho.net/plain',
+    'http://ifconfig.me/ip'
+  ];
 
   var get = function(i) {
     var url = urls[i];
@@ -50,6 +51,14 @@ exports.get_public_ip  = function(cb) {
       get(i+1);
     })
   };
+
+  if(typeof lookup_urls === 'function'){
+    cb = lookup_urls;
+  }
+
+  if(typeof lookup_urls === 'object' && lookup_urls.length > 0){
+    urls = lookup_urls;
+  }
 
   get(0);
 }
@@ -116,10 +125,5 @@ exports.get_active_interface = function(cb) {
   });
 
 };
-
-exports.set_lookup_urls = function(new_urls){
-
-  urls = new_urls;
-}
 
 exports.get_interfaces_list = os_functions.get_network_interfaces_list;


### PR DESCRIPTION
Sometimes the network environment makes the get_public_ip method return an invalid IP. In my case it's because the network caches the requests to DynDNS and returns the internal IP instead.

This PR allows the user to override what urls to check for an IP. This enables the user to either select one that's not cached or build their own.