### PR TITLE
Add netmask and gateway to interfacesList on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -65,8 +65,18 @@ exports.get_network_interfaces_list = function(cb) {
         if (!err && res)
           obj.type = res;
 
-        list.push(obj);
-        --count || cb(null, list);
+        exports.netmask_for(obj.name, function (err, res) {
+          if (!err && res)
+            obj.netmask = res.trim();
+
+          exports.gateway_ip_for(obj.name, function (err, res) {
+            if (!err && res)
+              obj.gateway_ip = res.toString().trim();
+
+            list.push(obj);
+            --count || cb(null, list);
+          })
+        })
       })
     })
   }


### PR DESCRIPTION
Netmask and Gateway were both missing (according to readme) from get_network_interfaces_list on Linux.

Fixed on Linux, looks to be missing on Darin too though.