### PR TITLE
made head command work on systems with busybox version

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -39,7 +39,7 @@ exports.mac_address_for = function(nic_name, cb) {
 };
 
 exports.gateway_ip_for = function(nic_name, cb) {
-  trim_exec("ip r | grep " + nic_name + " | grep default | cut -d ' ' -f 3 | head -1", cb);
+  trim_exec("ip r | grep " + nic_name + " | grep default | cut -d ' ' -f 3 | head -n1", cb);
 };
 
 exports.netmask_for = function(nic_name, cb) {


### PR DESCRIPTION
I am trying to use this library on an embedded system with busybox command and I get the following error when I try to get the gateway.

```
head: invalid option -- '1'
BusyBox v1.24.1 (2017-09-28 12:11:57 MDT) multi-call binary.
```