### PR TITLE
directly require platform specific files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,21 @@
 "use strict";
 
-var needle       = require('needle'),
-    os_functions = require('./' + process.platform);
+var needle = require('needle');
+
+var darwin = require('./darwin')
+var linux = require('./linux');
+var win32 = require('./win32');
+
+var os_functions;
+if (process.platform === 'darwin') {
+  os_functions = darwin;
+} else if (process.platform === 'linux') {
+  os_functions = linux;
+} else if (process.platform === 'win32') {
+  os_functions = win32;
+} else {
+  throw new Error('Unsupported platform')
+}
 
 // var ip_regex = /((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})/;
 var ip_regex = /(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)/;


### PR DESCRIPTION
Hi,

Thanks for your work on this library.

This PR is for a bit of a uncommon use case.

I'm using this in a library that is compiled to a cross platform binary using [nexe](https://github.com/nexe/nexe). Using `require('./' + process.platform);` breaks this.

The other benefit of this though is that it will throw an error when an unimplemented platform is used.