### PR TITLE
win32 catch no interfaces found

### DIFF
--- a/lib/win32.js
+++ b/lib/win32.js
@@ -58,9 +58,11 @@ exports.get_network_interfaces_list = function(callback) {
   }
 
   wmic.get_list('nic', function(err, nics) {
-    if (err) return callback(err);
-
+    if (err) return callback(err);    
     count = nics.length;
+    if (count == 0){
+      return cb(new Error('No interfaces found.'))
+    }
     nics.forEach(function(nic) {
       if (nic.Name && nic.NetConnectionID != '' && nic.MACAddress != '') {
 


### PR DESCRIPTION
I face with this error when no interfaces found then count == 0 , no cb is called