### PR TITLE
Recognize bluetooth interfaces in Mac OS X

### DIFF
--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -26,7 +26,9 @@ function determine_nic_type(str) {
              ? 'FireWire'
              : str.match(/Thunderbolt/)
                ? 'Thunderbolt'
-               : 'Other';
+               : str.match(/Bluetooth/)
+                 ? 'Bluetooth'
+                 : 'Other';
 }
 
 //////////////////////////////////////////


### PR DESCRIPTION
This PR returns type `Bluetooth` instead of `Other` for bluetooth interfaces