### PR TITLE
make require string const

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,18 @@
 "use strict";
 
-var needle       = require('needle'),
-    os_functions = require('./' + process.platform);
-
+var needle = require('needle');
+var os_functions;
+switch (process.platform) {
+  case 'win32':
+    os_functions = require('./win32');
+    break;
+  case 'linux':
+    os_functions = require('./linux');
+    break;
+  case 'darwin':
+    os_functions = require('./darwin');
+    break;
+}
 // var ip_regex = /((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})/;
 var ip_regex = /(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)/;
 


### PR DESCRIPTION
webpack doesn't support variable in require, it's a simple way to make it work, although there are some other ways.