### PR TITLE
Compatibility with node v18

### DIFF
--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -132,7 +132,7 @@ exports.get_network_interfaces_list = function(cb) {
       obj.mac_address = mac[1];
 
       (nics[obj.name] || []).forEach(function(type) {
-        if (type.family == 'IPv4') {
+        if (type.family == 'IPv4' || type.family == 4) {
           obj.ip_address = type.address;
         }
       });

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -85,7 +85,7 @@ exports.get_network_interfaces_list = function(cb) {
       var obj = { name: key };
 
       nics[key].forEach(function(type) {
-        if (type.family == 'IPv4') {
+        if (type.family == 'IPv4' || type.family == 4) {
           obj.ip_address = type.address;
         }
       });

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -79,7 +79,7 @@ exports.get_network_interfaces_list = function(callback) {
         var node_nic = node_nics[obj.name] || [];
 
         node_nic.forEach(function(type) {
-          if (type.family == 'IPv4') {
+          if (type.family == 'IPv4' || type.family == 4) {
             obj.ip_address = type.address;
           }
         });


### PR DESCRIPTION
Node version 18 has added an undocumented change to the os.networkInterfaces return values.
See: https://github.com/nodejs/node/issues/42787

This undocumented change results in this package no longer setting the ip_address field for interfaces with an IPv4 type.
This PR adds compatibility for that change. I was however only able to test this on Linux as I do not own any Mac or Windows machines.